### PR TITLE
update tested node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: node_js
 sudo: false
 
 node_js:
-  - 6
   - 8
   - 10
+  - 12
 
 cache: npm
 

--- a/tests/lab-gui-websocket.test.ts
+++ b/tests/lab-gui-websocket.test.ts
@@ -202,7 +202,8 @@ describe('Testing LabGuiWebsocket', () => {
     })
 
     it('wait for connection to time out', done => {
-      // timeout only gets called because it isn't reset by clearTimeout, which is why it needs to be mocked
+      // timeout only gets called because it isn't reset by clearTimeout,
+      // which is why clearTimeout needs to be mocked
       jest.useFakeTimers()
       const spyLog = jest.spyOn(global.console, 'log').mockImplementation()
       const spyClear = jest.spyOn(global, 'clearTimeout').mockImplementation()


### PR DESCRIPTION
Since node 6 is deprecated and node 12 is the current LTS, the tested node versions should be changed. 